### PR TITLE
403ページの追加 & 認可機能の修正

### DIFF
--- a/secure-interpreter-webssh/Dockerfile
+++ b/secure-interpreter-webssh/Dockerfile
@@ -1,8 +1,5 @@
 FROM --platform=linux/x86_64 python:3.11.5
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
 ADD . /code
 WORKDIR /code
 
@@ -11,6 +8,7 @@ RUN git clone https://github.com/huashengdun/webssh.git
 WORKDIR /code/webssh
 
 COPY index.html ./webssh/templates
+COPY page403.html ./webssh/templates
 COPY handler.py ./webssh
 
 RUN python ./setup.py build

--- a/secure-interpreter-webssh/page403.html
+++ b/secure-interpreter-webssh/page403.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Forbidden</title>
+</head>
+<body>
+    <h1>403 Forbidden</h1>
+    <p>
+        申し訳ありませんが、このページにアクセスする権限がありません。
+        管理者にご連絡ください。
+    </p>
+</body>
+</html>

--- a/secure-interpreter-webssh/requirements.txt
+++ b/secure-interpreter-webssh/requirements.txt
@@ -1,1 +1,0 @@
-requests


### PR DESCRIPTION
変更点
1. 403ページの追加
- 認可で許可されていないユーザーの場合に表示する403エラーをページを作成して表示する
- easy authの認可失敗後の403画面は表示されずに同じ403ページを表示
2. 認可処理の変更
- ms graph apiからグループ情報を取得していた部分をリクエストヘッダーからロールを取得して所属しているか検証
